### PR TITLE
Fix compiler warning(range-based for loop initialization statements are a C++20 extension

### DIFF
--- a/bktree/bktree.hpp
+++ b/bktree/bktree.hpp
@@ -566,7 +566,8 @@ bool BKTree<Metric>::erase(std::string_view value) {
     if (m_tree_size > 1) {
       auto &replacement_node = m_root->m_children.begin()->second;
       std::queue<std::unique_ptr<node_type> const *> bq;
-      for (bool first = true; auto const &[_, node] : m_root->m_children) {
+      bool first = true;
+      for (auto const &[_, node] : m_root->m_children) {
         if (first) {
           first = false;
           continue;


### PR DESCRIPTION
<!-- THANK YOU so much for submitting a pull request. Please fill out the details for easier reviews. -->

#### Fixes compiler error

```
bktree.hpp:569:12: warning: range-based for loop initialization statements are a C++20 extension [-Wc++20-extensions]
  569 |       for (bool first = true; auto const &[_, node] : m_root->m_children) {
      |            ^~~~~~~~~~~~~~~~~~
```

#### I confirm that my PR:

- [x] complies with the contribution guidelines

#### Changes:

move the declaration out of for loop

<!-- Fill in something related to the PR. -->